### PR TITLE
Launch dd-agent container for each ecs cluster instance

### DIFF
--- a/terraform/module_mastodon.tf
+++ b/terraform/module_mastodon.tf
@@ -52,5 +52,6 @@ module "mastodon" {
   mastodon_node_streaming_cluster_num                               = "${var.mastodon_node_streaming_cluster_num}"
   mastodon_vapid_private_key                                        = "${var.mastodon_vapid_private_key}"
   mastodon_vapid_public_key                                         = "${var.mastodon_vapid_public_key}"
+  mastodon_dd_agent_api_key                                         = "${var.mastodon_dd_agent_api_key}"
   source                                                            = "./modules/mastodon"
 }

--- a/terraform/modules/mastodon/aws_ecr_repository.tf
+++ b/terraform/modules/mastodon/aws_ecr_repository.tf
@@ -1,3 +1,7 @@
 resource "aws_ecr_repository" "mastodon" {
   name = "${var.aws_resource_base_name}"
 }
+
+resource "aws_ecr_repository" "mastodon_dd_agent" {
+  name = "${var.aws_resource_base_name}_dd_agent"
+}

--- a/terraform/modules/mastodon/aws_ecr_repository.tf
+++ b/terraform/modules/mastodon/aws_ecr_repository.tf
@@ -3,5 +3,5 @@ resource "aws_ecr_repository" "mastodon" {
 }
 
 resource "aws_ecr_repository" "mastodon_dd_agent" {
-  name = "${var.aws_resource_base_name}_dd_agent"
+  name = "${var.aws_resource_base_name}-dd-agent"
 }

--- a/terraform/modules/mastodon/aws_ecs_task_definition.tf
+++ b/terraform/modules/mastodon/aws_ecs_task_definition.tf
@@ -178,7 +178,7 @@ resource "aws_ecs_task_definition" "mastodon_dd_agent" {
         }
       ],
       "name": "dd-agent",
-      "image": "${replace(aws_ecr_repository.dd_agent.repository_url, "https://", "")}:${var.mastodon_docker_image_tag_dd_agent}",
+      "image": "datadog/docker-dd-agent:${var.mastodon_docker_image_tag_dd_agent}",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/terraform/modules/mastodon/aws_iam_role.tf
+++ b/terraform/modules/mastodon/aws_iam_role.tf
@@ -54,3 +54,22 @@ resource "aws_iam_role" "mastodon_rails" {
 
   name = "${var.aws_resource_base_name}_rails"
 }
+
+resource "aws_iam_role" "mastodon_dd_agent" {
+  assume_role_policy = <<-JSON
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  }
+  JSON
+
+  name = "${var.aws_resource_base_name}_dd_agent"
+}

--- a/terraform/modules/mastodon/aws_iam_role_policy.tf
+++ b/terraform/modules/mastodon/aws_iam_role_policy.tf
@@ -22,3 +22,26 @@ resource "aws_iam_role_policy" "mastodon_rails" {
 
   role = "${aws_iam_role.mastodon_rails.id}"
 }
+
+resource "aws_iam_role_policy" "mastodon_ec2" {
+  name = "${var.aws_resource_base_name}_ec2"
+
+  policy = <<-JSON
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ecs:StartTask"
+        ],
+        "Resource": [
+          "*"
+        ]
+      }
+    ]
+  }
+  JSON
+
+  role = "${aws_iam_role.mastodon_ec2.id}"
+}

--- a/terraform/modules/mastodon/aws_launch_configuration.tf
+++ b/terraform/modules/mastodon/aws_launch_configuration.tf
@@ -4,7 +4,7 @@ resource "aws_launch_configuration" "mastodon" {
   iam_instance_profile        = "${aws_iam_instance_profile.mastodon.id}"
   image_id                    = "${lookup(var.aws_ecs_optimized_ami_ids, data.aws_region.current.name)}"
   instance_type               = "${var.aws_launch_configuration_mastodon_instance_type}"
-  name_prefix                 = "mastodon-"
+  name_prefix                 = "${var.aws_resource_base_name}-"
   security_groups             = ["${aws_security_group.mastodon_web.id}"]
   user_data                   = "${data.template_file.mastodon_aws_launch_configuration_user_data.rendered}"
 

--- a/terraform/modules/mastodon/aws_launch_configuration.tf
+++ b/terraform/modules/mastodon/aws_launch_configuration.tf
@@ -2,7 +2,7 @@ resource "aws_launch_configuration" "mastodon" {
   associate_public_ip_address = true
   depends_on                  = ["aws_internet_gateway.mastodon"]
   iam_instance_profile        = "${aws_iam_instance_profile.mastodon.id}"
-  image_id                    = "${lookup(var.aws_ec2_coreos_ami_ids, data.aws_region.current.name)}"
+  image_id                    = "${lookup(var.aws_ecs_optimized_ami_ids, data.aws_region.current.name)}"
   instance_type               = "${var.aws_launch_configuration_mastodon_instance_type}"
   name_prefix                 = "mastodon-"
   security_groups             = ["${aws_security_group.mastodon_web.id}"]

--- a/terraform/modules/mastodon/aws_launch_configuration.tf
+++ b/terraform/modules/mastodon/aws_launch_configuration.tf
@@ -2,9 +2,9 @@ resource "aws_launch_configuration" "mastodon" {
   associate_public_ip_address = true
   depends_on                  = ["aws_internet_gateway.mastodon"]
   iam_instance_profile        = "${aws_iam_instance_profile.mastodon.id}"
-  image_id                    = "${lookup(var.aws_ecs_optimized_ami_ids, data.aws_region.current.name)}"
+  image_id                    = "${lookup(var.aws_ec2_coreos_ami_ids, data.aws_region.current.name)}"
   instance_type               = "${var.aws_launch_configuration_mastodon_instance_type}"
   name_prefix                 = "mastodon-"
   security_groups             = ["${aws_security_group.mastodon_web.id}"]
-  user_data                   = "#!/bin/bash\necho ECS_CLUSTER='${aws_ecs_cluster.mastodon.name}' >> /etc/ecs/ecs.config"
+  user_data                   = "${data.template_file.mastodon_aws_launch_configuration_user_data.rendered}"
 }

--- a/terraform/modules/mastodon/aws_launch_configuration.tf
+++ b/terraform/modules/mastodon/aws_launch_configuration.tf
@@ -7,4 +7,8 @@ resource "aws_launch_configuration" "mastodon" {
   name_prefix                 = "mastodon-"
   security_groups             = ["${aws_security_group.mastodon_web.id}"]
   user_data                   = "${data.template_file.mastodon_aws_launch_configuration_user_data.rendered}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/terraform/modules/mastodon/data.tf
+++ b/terraform/modules/mastodon/data.tf
@@ -278,52 +278,21 @@ data "template_file" "mastodon_environment_variables_streaming" {
 
 data "template_file" "mastodon_aws_launch_configuration_user_data" {
   template = <<-CONFIG
-  #cloud-config
-
-  coreos:
-    units:
-      - name: amazon-ecs-agent.service
-        command: start
-        runtime: true
-        content: |
-          [Unit]
-          Description=Amazon ECS Agent
-          After=docker.service
-          Requires=docker.service
-          Requires=network-online.target
-          After=network-online.target
-
-          [Service]
-          Environment=ECS_CLUSTER=$${aws_ecs_cluster_mastodon_name}
-          Environment=ECS_LOGLEVEL=warn
-          Environment=ECS_CHECKPOINT=true
-          ExecStartPre=-/usr/bin/docker kill ecs-agent
-          ExecStartPre=-/usr/bin/docker rm ecs-agent
-          ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent
-          ExecStart=/usr/bin/docker run --name ecs-agent --env=ECS_CLUSTER=$ECS_CLUSTER --env=ECS_LOGLEVEL=$ECS_LOGLEVEL --env=ECS_CHECKPOINT=$ECS_CHECKPOINT --publish=127.0.0.1:51678:51678 --volume=/var/run/docker.sock:/var/run/docker.sock --volume=/var/lib/aws/ecs:/data amazon/amazon-ecs- agent
-          ExecStop=/usr/bin/docker stop ecs-agent
-      - name: dd-agent.service
-        command: start
-        runtime: true
-        content: |
-          [Unit]
-          Description=Datadog Agent
-          After=amazon-ecs-agent.service
-          After=docker.service
-          After=network-online.target
-          Requires=amazon-ecs-agent.service
-          Requires=docker.service
-          Requires=network-online.target
-
-          [Service]
-          Environment=API_KEY=$${mastodon_dd_agent_api_key}
-          ExecStartPre=/usr/bin/docker pull datadog/docker-dd-agent:latest
-          ExecStart=/usr/bin/docker run --name dd-agent --env=API_KEY=$API_KEY --volume=/var/run/docker.sock:/var/run/docker.sock --volume=/proc/:/host/proc/:ro --volume=/sys/fs/cgroup/:/host/sys/fs/cgroup:ro datadog/docker-dd-agent:latest
-          ExecStop=/usr/bin/docker stop dd-agent
+  #!/bin/bash
+  cluster="$${aws_ecs_cluster_mastodon_name}"
+  task_def="$${aws_ecs_task_definition_mastodon_dd_agent_arn}"
+  echo ECS_CLUSTER=$cluster >> /etc/ecs/ecs.config
+  start ecs
+  yum install -y aws-cli jq
+  instance_arn=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $NF}' )
+  az=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  region=$(echo $az | rev | cut -c 2- | rev)
+  echo "cluster=$cluster az=$az region=$region aws ecs start-task --cluster \
+  $cluster --task-definition $task_def --container-instances $instance_arn --region $region" >> /etc/rc.local
   CONFIG
 
   vars {
-    aws_ecs_cluster_mastodon_name = "${aws_ecs_cluster.mastodon.name}"
-    mastodon_dd_agent_api_key     = "${var.mastodon_dd_agent_api_key}"
+    aws_ecs_task_definition_mastodon_dd_agent_arn = "${aws_ecs_task_definition.mastodon_dd_agent.family}"
+    aws_ecs_cluster_mastodon_name                 = "${aws_ecs_cluster.mastodon.name}"
   }
 }

--- a/terraform/modules/mastodon/variable.tf
+++ b/terraform/modules/mastodon/variable.tf
@@ -26,6 +26,22 @@ variable "aws_ecs_optimized_ami_ids" {
   }
 }
 
+variable "aws_ec2_coreos_ami_ids" {
+  default = {
+    "ap-northeast-1" = "ami-b50cfdd3"
+    "ap-southeast-1" = "ami-ed32568e"
+    "ap-southeast-2" = "ami-05aab266"
+    "ca-central-1"   = "ami-59a8163d"
+    "eu-central-1"   = "ami-33df775c"
+    "eu-west-1"      = "ami-109d6069"
+    "eu-west-2"      = "ami-7da3b219"
+    "us-east-1"      = "ami-ee774a95"
+    "us-east-2"      = "ami-a57251c0"
+    "us-west-1"      = "ami-e3ebc183"
+    "us-west-2"      = "ami-5106eb29"
+  }
+}
+
 variable "aws_ecs_service_desired_count_node_streaming" {}
 
 variable "aws_ecs_service_desired_count_rails_puma" {}
@@ -139,3 +155,5 @@ variable "mastodon_node_streaming_port" {
 variable "mastodon_vapid_private_key" {}
 
 variable "mastodon_vapid_public_key" {}
+
+variable "mastodon_dd_agent_api_key" {}

--- a/terraform/modules/mastodon/variable.tf
+++ b/terraform/modules/mastodon/variable.tf
@@ -26,22 +26,6 @@ variable "aws_ecs_optimized_ami_ids" {
   }
 }
 
-variable "aws_ec2_coreos_ami_ids" {
-  default = {
-    "ap-northeast-1" = "ami-b50cfdd3"
-    "ap-southeast-1" = "ami-ed32568e"
-    "ap-southeast-2" = "ami-05aab266"
-    "ca-central-1"   = "ami-59a8163d"
-    "eu-central-1"   = "ami-33df775c"
-    "eu-west-1"      = "ami-109d6069"
-    "eu-west-2"      = "ami-7da3b219"
-    "us-east-1"      = "ami-ee774a95"
-    "us-east-2"      = "ami-a57251c0"
-    "us-west-1"      = "ami-e3ebc183"
-    "us-west-2"      = "ami-5106eb29"
-  }
-}
-
 variable "aws_ecs_service_desired_count_node_streaming" {}
 
 variable "aws_ecs_service_desired_count_rails_puma" {}
@@ -85,6 +69,10 @@ variable "mastodon_default_locale" {}
 variable "mastodon_docker_image_tag" {}
 
 variable "mastodon_docker_image_tag_rails_db_migration" {}
+
+variable "mastodon_docker_image_tag_dd_agent" {
+  default = "latest"
+}
 
 variable "mastodon_email_domain_blacklist" {}
 

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -201,3 +201,7 @@ variable "mastodon_vapid_private_key" {
 variable "mastodon_vapid_public_key" {
   default = ""
 }
+
+variable "mastodon_dd_agent_api_key" {
+  default = ""
+}


### PR DESCRIPTION
Datadogを使ってアプリケーションのモニタリングを行うために、dd-agentを各ECSインスタンスに配置する。

- cloud-configを使ってamazon-ecs-agentとdd-agentを起動するために、 amiをプレーンなcoreosに変更した (amiのidは https://coreos.com/os/docs/latest/booting-on-ec2.html のものを使用している)
- user dataとしてcloud-configを起動時に渡して、amazon-ecs-agentとdd-agentを起動するようにした(http://docs.datadoghq.com/integrations/ecs/#create-a-new-coreos-instance のサンプルを元に追加した)
- `mastodon_dd_agent_api_key` 変数を追加して、外部から追加できるようにした