### PR TITLE
Cache frontend files placed by webpack on CloudFront

### DIFF
--- a/terraform/modules/mastodon/aws_cloudfront_distribution.tf
+++ b/terraform/modules/mastodon/aws_cloudfront_distribution.tf
@@ -25,6 +25,28 @@ resource "aws_cloudfront_distribution" "mastodon" {
     }
   }
 
+  cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    default_ttl            = 3600
+    max_ttl                = 86400
+    min_ttl                = 0
+    viewer_protocol_policy = "allow-all"
+    path_pattern           = "/packs/*"
+    compress               = true
+    target_origin_id       = "mastodon_alb"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+
+      headers = ["CloudFront-Forwarded-Proto", "Origin"]
+    }
+  }
+
   custom_error_response {
     error_caching_min_ttl = 0
     error_code            = 404


### PR DESCRIPTION
[Mastodon v1.4.1](https://github.com/tootsuite/mastodon/releases/tag/v1.4.1) places frontend files under `/mastodon/public/packs/` by using Webpack.
This PR enables caching of these files placed by Webpack.